### PR TITLE
Add option for s3 bucket force destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | bucket_tags | A map of tags to be applied to the Bucket. i.e {Environment='Development'} | map | `<map>` | no |
 | environment | Application environment for which this network is being created. must be one of ['Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test'] | string | `Development` | no |
 | expose_headers | Specifies expose header in the response. | list | `<list>` | no |
+| force_destroy_bucket | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
 | kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. | string | `` | no |
 | lifecycle_enabled | Enable object lifecycle management. i.e. true | false | string | `false` | no |
 | lifecycle_rule_prefix | Object keyname prefix identifying one or more objects to which the rule applies. Set as an empty string to target the whole bucket. | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -169,4 +169,6 @@ resource "aws_s3_bucket" "s3_bucket" {
   lifecycle_rule = "${local.lifecycle_rules[local.lifecycle_rules_config]}"
 
   cors_rule = "${local.cors_rules[local.cors_rules_config]}"
+
+  force_destroy = "${var.force_destroy_bucket}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "environment" {
   default     = "Development"
 }
 
+variable "force_destroy_bucket" {
+  description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
+  type        = "string"
+  default     = false
+}
+
 variable "kms_master_key_id" {
   description = "The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms."
   type        = "string"


### PR DESCRIPTION
Since this module will often be used by tests for other modules, we need an option to force destroy a provisioned bucket along with its contents. Default is set to `false`.