### PR TITLE
Enable configuration of default Multipart Uploads lifecycle rule (HCL2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It will not do s3 origin, which is in another module.
 
 ```HCL
 module "s3" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
 
   bucket_acl                                 = "bucket-owner-full-control"
   bucket_logging                             = false
@@ -76,6 +76,7 @@ The following module variables were updated to better meet current Rackspace sty
 | noncurrent\_version\_transition\_glacier\_days | Indicates after how many days we are moving previous versions to Glacier.  Should be 0 to disable or at least 30 days longer than noncurrent\_version\_transition\_ia\_days. i.e. 0 to disable, 1-999 otherwise | `number` | `0` | no |
 | noncurrent\_version\_transition\_ia\_days | Indicates after how many days we are moving previous version objects to Standard-IA storage. Set to 0 to disable. | `number` | `0` | no |
 | object\_expiration\_days | Indicates after how many days we are deleting current version of objects. Set to 0 to disable or at least 365 days longer than TransitionInDaysGlacier. i.e. 0 to disable, otherwise 1-999 | `number` | `0` | no |
+| rax\_mpu\_cleanup\_enabled | Enable Rackspace default values for cleanup of Multipart Uploads. | `bool` | `true` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256, aws:kms, and none | `string` | `"AES256"` | no |
 | tags | A map of tags to be applied to the Bucket. i.e {Environment='Development'} | `map(string)` | `{}` | no |
 | transition\_to\_glacier\_days | Indicates after how many days we are moving current versions to Glacier.  Should be 0 to disable or at least 30 days longer than transition\_to\_ia\_days. i.e. 0 to disable, otherwise 1-999 | `number` | `0` | no |

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -14,7 +14,7 @@ resource "random_string" "s3_rstring" {
 }
 
 module "s3" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
 
   bucket_logging                             = false
   bucket_acl                                 = "bucket-owner-full-control"
@@ -40,7 +40,7 @@ module "s3" {
 
 
 module "s3_no_website" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.2"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
 
   bucket_logging                             = false
   bucket_acl                                 = "bucket-owner-full-control"

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -1,5 +1,5 @@
 ###
-# This test adds the sse_algorithm option 'none'
+# This test adds the sse_algorithm option 'none' and disabled MPU cleanup
 ###
 
 terraform {
@@ -29,6 +29,7 @@ module "s3" {
   noncurrent_version_transition_glacier_days = "60"
   noncurrent_version_transition_ia_days      = "30"
   object_expiration_days                     = "425"
+  rax_mpu_cleanup_enabled                    = false
   sse_algorithm                              = "none"
   transition_to_glacier_days                 = "60"
   transition_to_ia_days                      = "30"

--- a/variables.tf
+++ b/variables.tf
@@ -112,6 +112,12 @@ variable "object_expiration_days" {
   default     = 0
 }
 
+variable "rax_mpu_cleanup_enabled" {
+  description = "Enable Rackspace default values for cleanup of Multipart Uploads."
+  type        = bool
+  default     = true
+}
+
 variable "sse_algorithm" {
   description = "The server-side encryption algorithm to use. Valid values are AES256, aws:kms, and none"
   type        = string


### PR DESCRIPTION
##### Corresponding Issue(s):
 - https://jira.rax.io/browse/MPCSUPENG-1601 (HCL2)

##### Summary of change(s):
Adds variable to either set S3 lifecycle rule to cleanup Multipart uploads or to set appropriate tag on bucket to prevent targeting by automation that enables this rule on existing buckets

##### Reason for Change(s):

- Eliminate manual drift within the IaC managed environment

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
