### PR TITLE
Add support for S3 Object Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ No Modules.
 
 | Name |
 |------|
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/s3_bucket) |
-| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/s3_bucket_public_access_block) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) |
 
 ## Inputs
 
@@ -99,6 +99,10 @@ No Modules.
 | noncurrent\_version\_transition\_glacier\_days | Indicates after how many days we are moving previous versions to Glacier.  Should be 0 to disable or at least 30 days longer than noncurrent\_version\_transition\_ia\_days. i.e. 0 to disable, 1-999 otherwise | `number` | `0` | no |
 | noncurrent\_version\_transition\_ia\_days | Indicates after how many days we are moving previous version objects to Standard-IA storage. Set to 0 to disable. | `number` | `0` | no |
 | object\_expiration\_days | Indicates after how many days we are deleting current version of objects. Set to 0 to disable or at least 365 days longer than TransitionInDaysGlacier. i.e. 0 to disable, otherwise 1-999 | `number` | `0` | no |
+| object\_lock\_enabled | Indicates whether this bucket has an Object Lock configuration enabled. Disabled by default. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support. | `bool` | `false` | no |
+| object\_lock\_mode | The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are GOVERNANCE and COMPLIANCE. Default is GOVERNANCE (allows administrative override). | `string` | `"GOVERNANCE"` | no |
+| object\_lock\_retention\_days | The retention of the object lock in days. Either days or years must be specified, but not both. | `number` | `null` | no |
+| object\_lock\_retention\_years | The retention of the object lock in years. Either days or years must be specified, but not both. | `number` | `null` | no |
 | rax\_mpu\_cleanup\_enabled | Enable Rackspace default values for cleanup of Multipart Uploads. | `bool` | `true` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256, aws:kms, and none | `string` | `"AES256"` | no |
 | tags | A map of tags to be applied to the Bucket. i.e {Environment='Development'} | `map(string)` | `{}` | no |

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -64,3 +64,33 @@ module "s3_no_website" {
     LeftSaid  = "George"
   }
 }
+
+module "s3_object_lock" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
+
+  bucket_acl                                 = "private"
+  bucket_logging                             = false
+  environment                                = "Development"
+  lifecycle_enabled                          = true
+  name                                       = "${random_string.s3_rstring.result}-example-s3-bucket"
+  noncurrent_version_expiration_days         = "425"
+  noncurrent_version_transition_glacier_days = "60"
+  noncurrent_version_transition_ia_days      = "30"
+  object_expiration_days                     = "425"
+  object_lock_enabled                        = true
+  object_lock_mode                           = "GOVERNANCE"
+  object_lock_retention_days                 = 1
+  rax_mpu_cleanup_enabled                    = false
+  sse_algorithm                              = "none"
+  transition_to_glacier_days                 = "60"
+  transition_to_ia_days                      = "30"
+  versioning                                 = true
+  website                                    = true
+  website_error                              = "error.html"
+  website_index                              = "index.html"
+
+  tags = {
+    RightSaid = "Fred"
+    LeftSaid  = "George"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -315,9 +315,11 @@ resource "aws_s3_bucket" "s3_bucket" {
       dynamic "rule" {
         for_each = lookup(object_lock_configuration.value, "rule", [])
         content {
-          mode  = lookup(rule.value, "mode", "GOVERNANCE")
-          days  = lookup(rule.value, "days", null)
-          years = lookup(rule.value, "years", null)
+          default_retention {
+            mode  = lookup(rule.value, "mode", "GOVERNANCE")
+            days  = lookup(rule.value, "days", null)
+            years = lookup(rule.value, "years", null)
+          }
         }
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,25 @@ locals {
   }
 
   ##############################################################
+  # Bucket object lock local variables
+  ##############################################################
+
+  object_lock_rule = {
+    Enabled = [
+      {
+        rule = [
+          {
+            mode  = var.object_lock_mode
+            days  = var.object_lock_retention_days
+            years = var.object_lock_retention_years
+          },
+        ]
+      },
+    ]
+    Disabled = []
+  }
+
+  ##############################################################
   # Server side encryption rule local variables
   ##############################################################
 
@@ -286,6 +305,21 @@ resource "aws_s3_bucket" "s3_bucket" {
     content {
       target_bucket = logging.value.target_bucket
       target_prefix = lookup(logging.value, "target_prefix", null)
+    }
+  }
+
+  dynamic "object_lock_configuration" {
+    for_each = local.object_lock_rule[var.object_lock_enabled ? "Enabled" : "Disabled"]
+    content {
+      object_lock_enabled = "Enabled" // The only valid value when this configuration is present
+      dynamic "rule" {
+        for_each = lookup(object_lock_configuration.value, "rule", [])
+        content {
+          mode  = lookup(rule.value, "mode", "GOVERNANCE")
+          days  = lookup(rule.value, "days", null)
+          years = lookup(rule.value, "years", null)
+        }
+      }
     }
   }
 

--- a/tests/test4/main.tf
+++ b/tests/test4/main.tf
@@ -1,9 +1,13 @@
+###
+# This test adds the sse_algorithm option 'none' and disabled MPU cleanup
+###
+
 terraform {
   required_version = ">= 0.12"
 }
 
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 
@@ -14,10 +18,10 @@ resource "random_string" "s3_rstring" {
 }
 
 module "s3" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
+  source = "../../module"
 
-  bucket_logging                             = false
   bucket_acl                                 = "private"
+  bucket_logging                             = false
   environment                                = "Development"
   lifecycle_enabled                          = true
   name                                       = "${random_string.s3_rstring.result}-example-s3-bucket"
@@ -28,36 +32,14 @@ module "s3" {
   object_lock_enabled                        = true
   object_lock_mode                           = "GOVERNANCE"
   object_lock_retention_days                 = 1
+  rax_mpu_cleanup_enabled                    = false
+  sse_algorithm                              = "none"
   transition_to_glacier_days                 = "60"
   transition_to_ia_days                      = "30"
   versioning                                 = true
   website                                    = true
   website_error                              = "error.html"
   website_index                              = "index.html"
-
-  tags = {
-    RightSaid = "Fred"
-    LeftSaid  = "George"
-  }
-}
-
-
-module "s3_no_website" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
-
-  bucket_logging                             = false
-  bucket_acl                                 = "private"
-  environment                                = "Development"
-  lifecycle_enabled                          = true
-  name                                       = "${random_string.s3_rstring.result}-example-s3-bucket-no-web"
-  noncurrent_version_expiration_days         = "425"
-  noncurrent_version_transition_glacier_days = "60"
-  noncurrent_version_transition_ia_days      = "30"
-  object_expiration_days                     = "425"
-  transition_to_glacier_days                 = "60"
-  transition_to_ia_days                      = "30"
-  versioning                                 = true
-  website                                    = false
 
   tags = {
     RightSaid = "Fred"

--- a/variables.tf
+++ b/variables.tf
@@ -142,6 +142,27 @@ variable "object_expiration_days" {
   default     = 0
 }
 
+variable "object_lock_enabled" {
+  description = "Indicates whether this bucket has an Object Lock configuration enabled. Disabled by default. You can only enable S3 Object Lock for new buckets. If you need to turn on S3 Object Lock for an existing bucket, please contact AWS Support."
+  type        = bool
+  default     = false
+}
+variable "object_lock_mode" {
+  description = "The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are GOVERNANCE and COMPLIANCE. Default is GOVERNANCE (allows administrative override)."
+  type        = string
+  default     = "GOVERNANCE"
+}
+variable "object_lock_retention_days" {
+  description = "The retention of the object lock in days. Either days or years must be specified, but not both."
+  type        = number
+  default     = null
+}
+variable "object_lock_retention_years" {
+  description = "The retention of the object lock in years. Either days or years must be specified, but not both."
+  type        = number
+  default     = null
+}
+
 variable "rax_mpu_cleanup_enabled" {
   description = "Enable Rackspace default values for cleanup of Multipart Uploads."
   type        = bool


### PR DESCRIPTION
##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):

Add support for S3 object lock by adding a `dynamic`  configuration.

##### Reason for Change(s):

- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).

To ensure the integrity of key logs and business critical files, we want to be able to set an S3 object lock with GOVERNANCE mode in testing, and COMPLIANCE in production (and a lock retention, of course).

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

Object lock should be enabled/disabled when the bucket is created. If you want to set it when the bucket is already created this requires contacting AWS support. Terraform will recreate the bucket if you flip the switch.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Unknown.

##### If input variables or output variables have changed or has been added, have you updated the README?

Readme updated with terraform-docs.

##### Do examples need to be updated based on changes?

Added an extra example with object lock.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
