### PR TITLE
Attach Bucket Policy as part of module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ No Modules.
 | bucket\_acl | Bucket ACL. Must be either authenticated-read, aws-exec-read, log-delivery-write, private, public-read or public-read-write. For more details https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl | `string` | `"private"` | no |
 | bucket\_logging | Enable bucket logging. Will store logs in another existing bucket. You must give the log-delivery group WRITE and READ\_ACP permissions to the target bucket. i.e. true \| false | `bool` | `false` | no |
 | bucket\_policy | A valid bucket policy JSON document to attach to this bucket. | `string` | `""` | no |
-| enable\_bucket\_policy | A boolean that indicates whether a custom bucket policy should be attached to his bucket. | `bool` | `false` | no |
+| enable\_bucket\_policy | A boolean that indicates whether a custom bucket policy should be attached to this bucket. | `bool` | `false` | no |
 | environment | Application environment for which this network is being created. must be one of ['Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test'] | `string` | `"Development"` | no |
 | expose\_headers | Specifies expose header in the response. | `list(string)` | `[]` | no |
 | force\_destroy\_bucket | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ No Modules.
 | Name |
 |------|
 | [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/s3_bucket) |
+| [aws_s3_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/s3_bucket_ownership_controls) |
+| [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/s3_bucket_policy) |
 | [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/2.7.0/docs/resources/s3_bucket_public_access_block) |
 
 ## Inputs
@@ -78,13 +80,15 @@ No Modules.
 | allowed\_headers | Specifies which headers are allowed. | `list(string)` | `[]` | no |
 | allowed\_methods | (Required) Specifies which methods are allowed. Can be GET, PUT, POST, DELETE or HEAD. | `list(string)` | `[]` | no |
 | allowed\_origins | (Required) Specifies which origins are allowed. | `list(string)` | `[]` | no |
-| block\_public\_access | Block various forms of public access on a per bucket level | `bool` | `false` | no |
+| block\_public\_access | Block various forms of public access on a per bucket level. | `bool` | `false` | no |
 | block\_public\_access\_acl | Related to block\_public\_access. PUT Bucket acl and PUT Object acl calls will fail if the specified ACL allows public access. PUT Object calls will fail if the request includes an object ACL. | `bool` | `true` | no |
 | block\_public\_access\_ignore\_acl | Related to block\_public\_access. Ignore public ACLs on this bucket and any objects that it contains. | `bool` | `true` | no |
 | block\_public\_access\_policy | Related to block\_public\_access. Reject calls to PUT Bucket policy if the specified bucket policy allows public access. | `bool` | `true` | no |
 | block\_public\_access\_restrict\_bucket | Related to block\_public\_access. Only the bucket owner and AWS Services can access this buckets if it has a public policy. | `bool` | `true` | no |
 | bucket\_acl | Bucket ACL. Must be either authenticated-read, aws-exec-read, log-delivery-write, private, public-read or public-read-write. For more details https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl | `string` | `"private"` | no |
 | bucket\_logging | Enable bucket logging. Will store logs in another existing bucket. You must give the log-delivery group WRITE and READ\_ACP permissions to the target bucket. i.e. true \| false | `bool` | `false` | no |
+| bucket\_policy | A valid bucket policy JSON document to attach to this bucket. | `string` | `""` | no |
+| enable\_bucket\_policy | A boolean that indicates whether a custom bucket policy should be attached to his bucket. | `bool` | `false` | no |
 | environment | Application environment for which this network is being created. must be one of ['Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test'] | `string` | `"Development"` | no |
 | expose\_headers | Specifies expose header in the response. | `list(string)` | `[]` | no |
 | force\_destroy\_bucket | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
@@ -103,6 +107,7 @@ No Modules.
 | object\_lock\_mode | The default Object Lock retention mode you want to apply to new objects placed in this bucket. Valid values are GOVERNANCE and COMPLIANCE. Default is GOVERNANCE (allows administrative override). | `string` | `"GOVERNANCE"` | no |
 | object\_lock\_retention\_days | The retention of the object lock in days. Either days or years must be specified, but not both. | `number` | `null` | no |
 | object\_lock\_retention\_years | The retention of the object lock in years. Either days or years must be specified, but not both. | `number` | `null` | no |
+| ownership\_controls | S3 Bucket Ownership Controls. Valid values are BucketOwnerPreferred and ObjectWriter. | `string` | `""` | no |
 | rax\_mpu\_cleanup\_enabled | Enable Rackspace default values for cleanup of Multipart Uploads. | `bool` | `true` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256, aws:kms, and none | `string` | `"AES256"` | no |
 | tags | A map of tags to be applied to the Bucket. i.e {Environment='Development'} | `map(string)` | `{}` | no |

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -14,7 +14,7 @@ resource "random_string" "s3_rstring" {
 }
 
 module "s3" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
 
   bucket_logging                             = false
   bucket_acl                                 = "private"
@@ -43,7 +43,7 @@ module "s3" {
 
 
 module "s3_no_website" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
 
   bucket_logging                             = false
   bucket_acl                                 = "private"
@@ -66,7 +66,7 @@ module "s3_no_website" {
 }
 
 module "s3_object_lock" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.3"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
 
   bucket_acl                                 = "private"
   bucket_logging                             = false
@@ -88,6 +88,55 @@ module "s3_object_lock" {
   website                                    = true
   website_error                              = "error.html"
   website_index                              = "index.html"
+
+  tags = {
+    RightSaid = "Fred"
+    LeftSaid  = "George"
+  }
+}
+
+module "s3_bucket_with_policy" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
+
+  bucket_acl                                 = "private"
+  bucket_logging                             = false
+  environment                                = "Development"
+  lifecycle_enabled                          = true
+  name                                       = "${random_string.s3_rstring.result}-example-s3-bucket"
+  noncurrent_version_expiration_days         = "425"
+  noncurrent_version_transition_glacier_days = "60"
+  noncurrent_version_transition_ia_days      = "30"
+  object_expiration_days                     = "425"
+  object_lock_enabled                        = true
+  object_lock_mode                           = "GOVERNANCE"
+  object_lock_retention_days                 = 1
+  rax_mpu_cleanup_enabled                    = false
+  sse_algorithm                              = "none"
+  transition_to_glacier_days                 = "60"
+  transition_to_ia_days                      = "30"
+  versioning                                 = true
+  website                                    = true
+  website_error                              = "error.html"
+  website_index                              = "index.html"
+
+
+  ownership_controls                         = "BucketOwnerPreferred"
+  bucket_policy                              = jsonencode({
+    Version = "2012-10-17"
+    Id      = "CloudTrailBucketPolicy"
+    Statement = [
+      {
+        Sid    = "AWSCloudTrailAclCheck",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        },
+        Action   = "s3:GetBucketAcl",
+        Resource = module.s3_bucket_with_policy.bucket_arn
+      }
+    ]
+  })
+
 
   tags = {
     RightSaid = "Fred"

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -120,8 +120,8 @@ module "s3_bucket_with_policy" {
   website_index                              = "index.html"
 
 
-  ownership_controls                         = "BucketOwnerPreferred"
-  bucket_policy                              = jsonencode({
+  ownership_controls = "BucketOwnerPreferred"
+  bucket_policy = jsonencode({
     Version = "2012-10-17"
     Id      = "CloudTrailBucketPolicy"
     Statement = [

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -14,7 +14,7 @@ resource "random_string" "s3_rstring" {
 }
 
 module "s3" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.8"
 
   bucket_logging                             = false
   bucket_acl                                 = "private"
@@ -43,7 +43,7 @@ module "s3" {
 
 
 module "s3_no_website" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.8"
 
   bucket_logging                             = false
   bucket_acl                                 = "private"
@@ -66,7 +66,7 @@ module "s3_no_website" {
 }
 
 module "s3_object_lock" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.8"
 
   bucket_acl                                 = "private"
   bucket_logging                             = false
@@ -96,7 +96,7 @@ module "s3_object_lock" {
 }
 
 module "s3_bucket_with_policy" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.7"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.8"
 
   bucket_acl                                 = "private"
   bucket_logging                             = false

--- a/main.tf
+++ b/main.tf
@@ -397,5 +397,5 @@ resource "aws_s3_bucket_policy" "bucket_policy" {
 
   policy = var.bucket_policy
 
-  depends_on = [aws_s3_bucket_public_access_block.block_public_access_settings]
+  depends_on = [aws_s3_bucket_ownership_controls.ownership_controls]
 }

--- a/main.tf
+++ b/main.tf
@@ -392,7 +392,7 @@ resource "aws_s3_bucket_ownership_controls" "ownership_controls" {
 # S3 Bucket policy
 ##############################################################
 resource "aws_s3_bucket_policy" "bucket_policy" {
-  count  = var.bucket_policy != "" ? 1 : 0
+  count  = var.enable_bucket_policy ? 1 : 0
   bucket = aws_s3_bucket.s3_bucket.id
 
   policy = var.bucket_policy

--- a/main.tf
+++ b/main.tf
@@ -372,3 +372,30 @@ resource "aws_s3_bucket_public_access_block" "block_public_access_settings" {
   ignore_public_acls      = var.block_public_access_ignore_acl
   restrict_public_buckets = var.block_public_access_restrict_bucket
 }
+
+##############################################################
+# Ownership Control Settings
+##############################################################
+
+resource "aws_s3_bucket_ownership_controls" "ownership_controls" {
+  count  = var.ownership_controls != "" ? 1 : 0
+  bucket = aws_s3_bucket.s3_bucket.id
+
+  rule {
+    object_ownership = var.ownership_controls
+  }
+
+  depends_on = [aws_s3_bucket_public_access_block.block_public_access_settings]
+}
+
+##############################################################
+# S3 Bucket policy
+##############################################################
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  count  = var.bucket_policy != "" ? 1 : 0
+  bucket = aws_s3_bucket.s3_bucket.id
+
+  policy = var.bucket_policy
+
+  depends_on = [aws_s3_bucket_public_access_block.block_public_access_settings]
+}

--- a/tests/test5/main.tf
+++ b/tests/test5/main.tf
@@ -8,10 +8,7 @@ terraform {
 
 provider "aws" {
   version = "~> 3.0"
-  region  = "eu-west-1"
-
-  shared_credentials_file = "/Users/martijnvandegrift/.aws/credentials"
-  profile                 = "martijnbinx"
+  region  = "us-west-2"
 }
 
 resource "random_string" "s3_rstring" {

--- a/tests/test5/main.tf
+++ b/tests/test5/main.tf
@@ -1,0 +1,69 @@
+###
+# This test adds the sse_algorithm option 'none' and disabled MPU cleanup
+###
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+provider "aws" {
+  version = "~> 3.0"
+  region  = "eu-west-1"
+
+  shared_credentials_file = "/Users/martijnvandegrift/.aws/credentials"
+  profile                 = "martijnbinx"
+}
+
+resource "random_string" "s3_rstring" {
+  length  = 18
+  special = false
+  upper   = false
+}
+
+module "s3" {
+  source = "../../module"
+
+  bucket_acl                                 = "private"
+  bucket_logging                             = false
+  environment                                = "Development"
+  lifecycle_enabled                          = true
+  name                                       = "${random_string.s3_rstring.result}-example-s3-bucket"
+  noncurrent_version_expiration_days         = "425"
+  noncurrent_version_transition_glacier_days = "60"
+  noncurrent_version_transition_ia_days      = "30"
+  object_expiration_days                     = "425"
+  object_lock_enabled                        = true
+  object_lock_mode                           = "GOVERNANCE"
+  object_lock_retention_days                 = 1
+  rax_mpu_cleanup_enabled                    = false
+  sse_algorithm                              = "none"
+  transition_to_glacier_days                 = "60"
+  transition_to_ia_days                      = "30"
+  versioning                                 = true
+  website                                    = true
+  website_error                              = "error.html"
+  website_index                              = "index.html"
+
+  ownership_controls                         = "BucketOwnerPreferred"
+  enable_bucket_policy                       = true
+  bucket_policy                              = jsonencode({
+    Version = "2012-10-17"
+    Id      = "CloudTrailBucketPolicy"
+    Statement = [
+      {
+        Sid    = "AWSCloudTrailAclCheck",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudtrail.amazonaws.com"
+        },
+        Action   = "s3:GetBucketAcl",
+        Resource = module.s3.bucket_arn
+      }
+    ]
+  })
+
+  tags = {
+    RightSaid = "Fred"
+    LeftSaid  = "George"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "environment" {
 }
 
 variable "enable_bucket_policy" {
-  description = "A boolean that indicates whether a custom bucket policy should be attached to his bucket."
+  description = "A boolean that indicates whether a custom bucket policy should be attached to this bucket."
   type        = bool
   default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "bucket_logging" {
   default     = false
 }
 
+variable "bucket_policy" {
+  description = "A valid bucket policy JSON document to attach to this bucket."
+  type        = string
+  default     = ""
+}
+
 variable "block_public_access" {
   description = "Block various forms of public access on a per bucket level"
   type        = bool
@@ -161,6 +167,12 @@ variable "object_lock_retention_years" {
   description = "The retention of the object lock in years. Either days or years must be specified, but not both."
   type        = number
   default     = null
+}
+
+variable "ownership_controls" {
+  description = "S3 Bucket Ownership Controls. Valid values are BucketOwnerPreferred and ObjectWriter."
+  type        = string
+  default     = ""
 }
 
 variable "rax_mpu_cleanup_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "bucket_policy" {
 }
 
 variable "block_public_access" {
-  description = "Block various forms of public access on a per bucket level"
+  description = "Block various forms of public access on a per bucket level."
   type        = bool
   default     = false
 }
@@ -69,6 +69,12 @@ variable "environment" {
   description = "Application environment for which this network is being created. must be one of ['Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test']"
   type        = string
   default     = "Development"
+}
+
+variable "enable_bucket_policy" {
+  description = "A boolean that indicates whether a custom bucket policy should be attached to his bucket."
+  type        = bool
+  default     = false
 }
 
 variable "expose_headers" {


### PR DESCRIPTION

##### Summary of change(s):
Supercedes #25 
##### Reason for Change(s):

- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).
Easier way to add Bucket policies and Ownership controls. An additional benefit is that with everything in this module, you can set explicit DependsOns. Without this you get: `A conflicting conditional operation is currently in progress against this resource.` errors when performing operations on `aws_s3_bucket_public_access_block` and `aws_s3_bucket_ownership_controls`

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
yes

##### Do examples need to be updated based on changes?
New example is added.

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
