### PR TITLE
Bugfixes for S3 and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It will not do s3 origin, which is in another module.
 
 ```HCL
 module "s3_basic" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.12"
 
   bucket_logging    = false
   bucket_acl        = "private"
@@ -50,13 +50,13 @@ The following module variables were updated to better meet current Rackspace sty
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
-| aws | ~> 3.0 |
+| aws | ~> 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| aws | ~> 4.0 |
 
 ## Modules
 
@@ -66,17 +66,19 @@ No Modules.
 
 | Name |
 |------|
-| [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/canonical_user_id) |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket) |
-| [aws_s3_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_acl) |
-| [aws_s3_bucket_cors_configuration](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_cors_configuration) |
-| [aws_s3_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_lifecycle_configuration) |
-| [aws_s3_bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_logging) |
-| [aws_s3_bucket_object_lock_configuration](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_object_lock_configuration) |
-| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_public_access_block) |
-| [aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_server_side_encryption_configuration) |
-| [aws_s3_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_versioning) |
-| [aws_s3_bucket_website_configuration](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_website_configuration) |
+| [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/data-sources/canonical_user_id) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket) |
+| [aws_s3_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_acl) |
+| [aws_s3_bucket_cors_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_cors_configuration) |
+| [aws_s3_bucket_intelligent_tiering_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_intelligent_tiering_configuration) |
+| [aws_s3_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_lifecycle_configuration) |
+| [aws_s3_bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_logging) |
+| [aws_s3_bucket_metric](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_metric) |
+| [aws_s3_bucket_object_lock_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_object_lock_configuration) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_public_access_block) |
+| [aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_server_side_encryption_configuration) |
+| [aws_s3_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_versioning) |
+| [aws_s3_bucket_website_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_website_configuration) |
 
 ## Inputs
 
@@ -92,11 +94,13 @@ No Modules.
 | bucket\_logging | Enable bucket logging. Will store logs in another existing bucket. You must give the log-delivery group WRITE and READ\_ACP permissions to the target bucket. i.e. true \| false | `bool` | `false` | no |
 | cors | Enable CORS Rules. Rules must be defined in the variable cors\_rules | `bool` | `false` | no |
 | cors\_rule | List of maps containing rules for Cross-Origin Resource Sharing. | `any` | `[]` | no |
+| enable\_bucket\_metrics | Enable bucket metrics | `bool` | `false` | no |
+| enable\_intelligent\_tiering | Enable intelligent tiering | `bool` | `false` | no |
 | environment | Application environment for which this network is being created. must be one of ['Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test'] | `string` | `"Development"` | no |
 | expected\_bucket\_owner | The account ID of the expected bucket owner | `string` | `null` | no |
 | force\_destroy\_bucket | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | intelligent\_tiering | Map containing intelligent tiering configuration. | `any` | `{}` | no |
-| kms\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. | `string` | `""` | no |
+| kms\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. | `string` | `null` | no |
 | lifecycle\_enabled | Enable object lifecycle management. i.e. true \| false | `bool` | `false` | no |
 | lifecycle\_rule | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | logging\_bucket\_name | Name of the existing bucket where the logs will be stored. | `string` | `""` | no |

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
 
     }
   }
@@ -21,7 +21,7 @@ resource "random_string" "s3_rstring" {
 }
 
 module "s3_basic" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.12"
 
   bucket_logging    = false
   bucket_acl        = "private"
@@ -47,7 +47,7 @@ module "s3_basic" {
 module "s3_website_with_cors" {
   # Websites and CORS have undergone a significant refactor since v0.12.7 due to features that added to their complexity.
   # Follow this example if you are using v0.12.10+
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.12"
 
   bucket_acl     = "private"
   bucket_logging = false
@@ -102,7 +102,7 @@ module "s3_website_with_cors" {
 }
 
 module "s3_object_lock" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.12"
 
   bucket_acl                 = "private"
   bucket_logging             = false
@@ -122,7 +122,7 @@ module "s3_object_lock" {
 module "s3_with_lifecycle" {
   # Lifecycle has undergone a significant refactor since v0.12.7 due to features that added to their complexity.
   # Follow this example if you are using v0.12.10+
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.11"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.12"
 
   bucket_acl        = "private"
   bucket_logging    = false

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
 
     }
   }

--- a/tests/test2/main.tf
+++ b/tests/test2/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
 
     }
   }

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
 
     }
   }
@@ -27,12 +27,13 @@ resource "random_string" "s3_rstring" {
 module "s3_lifecycle" {
   source = "../../module"
 
-  bucket_acl        = "private"
-  bucket_logging    = false
-  environment       = "Development"
-  name              = "${random_string.s3_rstring.result}-example-s3-bucket"
-  versioning        = true
-  lifecycle_enabled = true
+  bucket_acl                 = "private"
+  bucket_logging             = false
+  environment                = "Development"
+  name                       = "${random_string.s3_rstring.result}-example-s3-bucket"
+  versioning                 = true
+  enable_bucket_metrics      = true
+  lifecycle_enabled          = true
   lifecycle_rule = [
     {
       id      = "log"
@@ -105,37 +106,6 @@ module "s3_lifecycle" {
       }
     },
   ]
-
-  intelligent_tiering = {
-    general = {
-      status = "Enabled"
-      filter = {
-        prefix = "/"
-        tags = {
-          Environment = "dev"
-        }
-      }
-      tiering = {
-        ARCHIVE_ACCESS = {
-          days = 180
-        }
-      }
-    },
-    documents = {
-      status = false
-      filter = {
-        prefix = "documents/"
-      }
-      tiering = {
-        ARCHIVE_ACCESS = {
-          days = 125
-        }
-        DEEP_ARCHIVE_ACCESS = {
-          days = 200
-        }
-      }
-    }
-  }
 
   metric_configuration = [
     {

--- a/tests/test4/main.tf
+++ b/tests/test4/main.tf
@@ -1,5 +1,5 @@
 ###
-# SSE & bucket key test
+# SSE, bucket key test, and intelligent tiering test
 ###
 
 terraform {
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
 
     }
   }
@@ -27,17 +27,49 @@ resource "random_string" "s3_rstring" {
 module "s3" {
   source = "../../module"
 
-  bucket_acl         = "private"
-  bucket_logging     = false
-  environment        = "Development"
-  name               = "${random_string.s3_rstring.result}-example-s3-bucket"
-  versioning         = true
-  kms_key_id         = "aws/s3"
-  sse_algorithm      = "aws:kms"
+  bucket_acl                 = "private"
+  bucket_logging             = false
+  environment                = "Development"
+  name                       = "${random_string.s3_rstring.result}-example-s3-bucket"
+  versioning                 = true
+  kms_key_id                 = "aws/s3"
+  sse_algorithm              = "aws:kms"
+  enable_intelligent_tiering = true
   bucket_key_enabled = true
 
   tags = {
     RightSaid = "Fred"
     LeftSaid  = "George"
+  }
+
+    intelligent_tiering = {
+    general = {
+      status = "Enabled"
+      filter = {
+        prefix = "/"
+        tags = {
+          Environment = "dev"
+        }
+      }
+      tiering = {
+        ARCHIVE_ACCESS = {
+          days = 180
+        }
+      }
+    },
+    documents = {
+      status = false
+      filter = {
+        prefix = "documents/"
+      }
+      tiering = {
+        ARCHIVE_ACCESS = {
+          days = 125
+        }
+        DEEP_ARCHIVE_ACCESS = {
+          days = 200
+        }
+      }
+    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 variable "bucket_acl" {
   description = "Bucket ACL. Must be either authenticated-read, aws-exec-read, log-delivery-write, private, public-read or public-read-write. For more details https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl"
   type        = string
@@ -49,18 +48,6 @@ variable "environment" {
 
 variable "force_destroy_bucket" {
   description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable."
-  type        = bool
-  default     = false
-}
-
-variable "kms_key_id" {
-  description = "The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms."
-  type        = string
-  default     = ""
-}
-
-variable "bucket_key_enabled" {
-  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
   type        = bool
   default     = false
 }
@@ -148,6 +135,18 @@ variable "sse_algorithm" {
   default     = "AES256"
 }
 
+variable "kms_key_id" {
+  description = "The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms."
+  type        = string
+  default     = null
+}
+
+variable "bucket_key_enabled" {
+  description = "Whether or not to use Amazon S3 Bucket Keys for SSE-KMS."
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "A map of tags to be applied to the Bucket. i.e {Environment='Development'}"
   type        = map(string)
@@ -194,4 +193,16 @@ variable "expected_bucket_owner" {
   description = "The account ID of the expected bucket owner"
   type        = string
   default     = null
+}
+
+variable "enable_intelligent_tiering" {
+  description = "Enable intelligent tiering"
+  type        = bool
+  default     = false
+}
+
+variable "enable_bucket_metrics" {
+  description = "Enable bucket metrics"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
So there is a major bug when you move to the new modules in the 3.0 provider. Essentially Server Side Encryption and Lifecycle conflict with each other. This is resolved in provider 4.0. I have bumped this module to the 4.0 AWS provider. As we have a need for both lifecycles and encryption at the same time without deprecations.

- Updated readme
- Added missing object lock var from main bucket function
- Added support for intelligent tiering
- Added a test for intelligent tiering
- Added support for S3 metrics