### PR TITLE
Update Bucket ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ module "s3_basic" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-s3//?ref=v0.12.12"
 
   bucket_logging    = false
-  bucket_acl        = "private"
   environment       = "Development"
   name              = "${random_string.s3_rstring.result}-example-s3-bucket"
   versioning        = true
@@ -75,6 +74,7 @@ No Modules.
 | [aws_s3_bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_logging) |
 | [aws_s3_bucket_metric](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_metric) |
 | [aws_s3_bucket_object_lock_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_object_lock_configuration) |
+| [aws_s3_bucket_ownership_controls](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_ownership_controls) |
 | [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_public_access_block) |
 | [aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_server_side_encryption_configuration) |
 | [aws_s3_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/s3_bucket_versioning) |
@@ -84,14 +84,15 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| acl | (Optional) The canned ACL to apply. Conflicts with `grant` | `string` | `null` | no |
 | block\_public\_access | Block various forms of public access on a per bucket level | `bool` | `false` | no |
 | block\_public\_access\_acl | Related to block\_public\_access. PUT Bucket acl and PUT Object acl calls will fail if the specified ACL allows public access. PUT Object calls will fail if the request includes an object ACL. | `bool` | `true` | no |
 | block\_public\_access\_ignore\_acl | Related to block\_public\_access. Ignore public ACLs on this bucket and any objects that it contains. | `bool` | `true` | no |
 | block\_public\_access\_policy | Related to block\_public\_access. Reject calls to PUT Bucket policy if the specified bucket policy allows public access. | `bool` | `true` | no |
 | block\_public\_access\_restrict\_bucket | Related to block\_public\_access. Only the bucket owner and AWS Services can access this buckets if it has a public policy. | `bool` | `true` | no |
-| bucket\_acl | Bucket ACL. Must be either authenticated-read, aws-exec-read, log-delivery-write, private, public-read or public-read-write. For more details https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl | `string` | `"private"` | no |
 | bucket\_key\_enabled | Whether or not to use Amazon S3 Bucket Keys for SSE-KMS. | `bool` | `false` | no |
 | bucket\_logging | Enable bucket logging. Will store logs in another existing bucket. You must give the log-delivery group WRITE and READ\_ACP permissions to the target bucket. i.e. true \| false | `bool` | `false` | no |
+| control\_object\_ownership | Whether to manage S3 Bucket Ownership Controls on this bucket. | `bool` | `false` | no |
 | cors | Enable CORS Rules. Rules must be defined in the variable cors\_rules | `bool` | `false` | no |
 | cors\_rule | List of maps containing rules for Cross-Origin Resource Sharing. | `any` | `[]` | no |
 | enable\_bucket\_metrics | Enable bucket metrics | `bool` | `false` | no |
@@ -99,6 +100,7 @@ No Modules.
 | environment | Application environment for which this network is being created. must be one of ['Development', 'Integration', 'PreProduction', 'Production', 'QA', 'Staging', 'Test'] | `string` | `"Development"` | no |
 | expected\_bucket\_owner | The account ID of the expected bucket owner | `string` | `null` | no |
 | force\_destroy\_bucket | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
+| grant | An ACL policy grant. Conflicts with `acl` | `any` | `[]` | no |
 | intelligent\_tiering | Map containing intelligent tiering configuration. | `any` | `{}` | no |
 | kms\_key\_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. | `string` | `null` | no |
 | lifecycle\_enabled | Enable object lifecycle management. i.e. true \| false | `bool` | `false` | no |
@@ -114,6 +116,8 @@ No Modules.
 | object\_lock\_retention\_days | The retention of the object lock in days. Either days or years must be specified, but not both. | `number` | `null` | no |
 | object\_lock\_retention\_years | The retention of the object lock in years. Either days or years must be specified, but not both. | `number` | `null` | no |
 | object\_lock\_token | A token to allow Object Lock to be enabled for an existing bucket. You must contact AWS support for the bucket's 'Object Lock token'. The token is generated in the back-end when versioning is enabled on a bucket. | `string` | `null` | no |
+| object\_ownership | Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. 'BucketOwnerEnforced': ACLs are disabled, and the bucket owner automatically owns and has full control over every object in the bucket. 'BucketOwnerPreferred': Objects uploaded to the bucket change ownership to the bucket owner if the objects are uploaded with the bucket-owner-full-control canned ACL. 'ObjectWriter': The uploading account will own the object if the object is uploaded with the bucket-owner-full-control canned ACL. | `string` | `"ObjectWriter"` | no |
+| owner | Bucket owner's display name and ID. Conflicts with `acl` | `map(string)` | `{}` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256, aws:kms, and none | `string` | `"AES256"` | no |
 | tags | A map of tags to be applied to the Bucket. i.e {Environment='Development'} | `map(string)` | `{}` | no |
 | versioning | Enable bucket versioning. | `bool` | `false` | no |

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -27,7 +27,6 @@ resource "random_string" "s3_rstring" {
 module "s3" {
   source = "../../module"
 
-  bucket_acl        = "private"
   bucket_logging    = false
   environment       = "Development"
   name              = "${random_string.s3_rstring.result}-example-s3-bucket"

--- a/tests/test2/main.tf
+++ b/tests/test2/main.tf
@@ -27,13 +27,14 @@ resource "random_string" "s3_rstring" {
 module "s3" {
   source = "../../module"
 
-  bucket_acl     = "private"
-  bucket_logging = false
-  environment    = "Development"
-  name           = "${random_string.s3_rstring.result}-example-s3-bucket"
-  versioning     = true
-  website        = true
-  website_config = {
+  control_object_ownership = true
+  acl                      = "private"
+  bucket_logging           = false
+  environment              = "Development"
+  name                     = "${random_string.s3_rstring.result}-example-s3-bucket"
+  versioning               = true
+  website                  = true
+  website_config           = {
     index_document = "index.html"
     error_document = "error.html"
     routing_rules = [{

--- a/tests/test3/main.tf
+++ b/tests/test3/main.tf
@@ -27,7 +27,6 @@ resource "random_string" "s3_rstring" {
 module "s3_lifecycle" {
   source = "../../module"
 
-  bucket_acl            = "private"
   bucket_logging        = false
   environment           = "Development"
   name                  = "${random_string.s3_rstring.result}-example-s3-bucket"

--- a/tests/test4/main.tf
+++ b/tests/test4/main.tf
@@ -27,7 +27,6 @@ resource "random_string" "s3_rstring" {
 module "s3" {
   source = "../../module"
 
-  bucket_acl                 = "private"
   bucket_logging             = false
   environment                = "Development"
   name                       = "${random_string.s3_rstring.result}-example-s3-bucket"

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,3 @@
-variable "bucket_acl" {
-  description = "Bucket ACL. Must be either authenticated-read, aws-exec-read, log-delivery-write, private, public-read or public-read-write. For more details https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl"
-  type        = string
-  default     = "private"
-}
-
 variable "bucket_logging" {
   description = "Enable bucket logging. Will store logs in another existing bucket. You must give the log-delivery group WRITE and READ_ACP permissions to the target bucket. i.e. true | false"
   type        = bool
@@ -205,4 +199,34 @@ variable "enable_bucket_metrics" {
   description = "Enable bucket metrics"
   type        = bool
   default     = false
+}
+
+variable "owner" {
+  description = "Bucket owner's display name and ID. Conflicts with `acl`"
+  type        = map(string)
+  default     = {}
+}
+
+variable "acl" {
+  description = "(Optional) The canned ACL to apply. Conflicts with `grant`"
+  type        = string
+  default     = null
+}
+
+variable "grant" {
+  description = "An ACL policy grant. Conflicts with `acl`"
+  type        = any
+  default     = []
+}
+
+variable "control_object_ownership" {
+  description = "Whether to manage S3 Bucket Ownership Controls on this bucket."
+  type        = bool
+  default     = false
+}
+
+variable "object_ownership" {
+  description = "Object ownership. Valid values: BucketOwnerEnforced, BucketOwnerPreferred or ObjectWriter. 'BucketOwnerEnforced': ACLs are disabled, and the bucket owner automatically owns and has full control over every object in the bucket. 'BucketOwnerPreferred': Objects uploaded to the bucket change ownership to the bucket owner if the objects are uploaded with the bucket-owner-full-control canned ACL. 'ObjectWriter': The uploading account will own the object if the object is uploaded with the bucket-owner-full-control canned ACL."
+  type        = string
+  default     = "ObjectWriter"
 }


### PR DESCRIPTION
- AWS changed how ACLs work on S3 buckets. This updates the module to be compatible
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

Starting in April 2023, Amazon S3 will change the default settings for S3 Block Public Access and Object Ownership (ACLs disabled) for all new S3 buckets. For new buckets created after this update, all S3 Block Public Access settings will be enabled, and S3 access control lists (ACLs) will be disabled. These defaults are the recommended best practices for securing data in Amazon S3. You can adjust these settings after creating your bucket.

